### PR TITLE
[Upgrade] Bach 2.0.0-SNAPSHOT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 MadHax, LLC http://madhax.io
+Copyright (c) 2020 Erik Vavro http://madhax.ninja
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ That's it :sparkles:
 
 ## License
 
-Copyright © 2017 MadHax, LLC
+Copyright © 2020 Erik Vavro
 
 MIT

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject bach-rest-api "1.0.0"
+(defproject bach-rest-api "2.0.0"
   :description "Simple RESTful HTTP interface for the official Bach library"
   :url "http://github.com/slurmulon/bach-rest-api"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [bach "1.0.0-SNAPSHOT"]
+                 [bach "2.0.0-SNAPSHOT"]
                  [compojure "1.5.1"]
                  [ring/ring-json "0.4.0"]
                  [ring-json-response "0.2.0"]

--- a/src/bach_rest_api/handler.clj
+++ b/src/bach_rest_api/handler.clj
@@ -1,6 +1,5 @@
 (ns bach-rest-api.handler
-  (:require [bach.ast :as ast]
-            [bach.track :refer [compile-track]]
+  (:require [bach.track :refer [compose]]
             [compojure.core :refer :all]
             [compojure.route :as route]
             [ring.util.json-response :refer [json-response]]
@@ -13,7 +12,7 @@
   (POST "/track" {body :body}
         (let [source (slurp body)]
           (try
-            (let [track (-> source ast/parse compile-track)]
+            (let [track (compose source)]
               (log/info "[bach-rest-api/track] Valid track compiled. Source Bach data:")
               (log/info (prn source))
               (json-response track))


### PR DESCRIPTION
**Changes**
 - :recycle: Updated `/track` resource handler to use `bach/2.0.0-SNAPSHOT` interface
 - :package: Updated version to `2.0.0` (breaking change, input now has to match version `2.0.0` of `bach-json-schema`)